### PR TITLE
Added `getTransactionStatusByReference()` to the Transactions class, …

### DIFF
--- a/src/Transactions.php
+++ b/src/Transactions.php
@@ -153,6 +153,43 @@ abstract class Transactions
 
 
     /**
+     * Get the status of a transaction using either the Monnify transaction reference
+     * or the merchant's payment reference as a query parameter.
+     *
+     * @param string|null $transactionReference The Monnify-generated reference (URL-encoded).
+     * @param string|null $paymentReference The merchant-generated reference (URL-encoded).
+     * @return object
+     *
+     * @throws \InvalidArgumentException
+     * @throws MonnifyFailedRequestException
+     * @link https://developers.monnify.com/api#tag/transactions/get-transaction-status-by-reference
+     */
+    public function getTransactionStatusByReference(string $transactionReference = null, string $paymentReference = null): object
+    {
+        if (is_null($transactionReference) && is_null($paymentReference))
+            throw new \InvalidArgumentException("At least one of transactionReference or paymentReference must be provided.");
+
+        $queryParams = array_filter([
+            'transactionReference' => $transactionReference,
+            'paymentReference'     => $paymentReference,
+        ]);
+
+        $endpoint = "{$this->monnify->baseUrl}{$this->monnify->v2}merchant/transactions/query?" . http_build_query($queryParams);
+
+        $response = $this->monnify->withOAuth2()->get($endpoint);
+
+        $responseObject = json_decode($response->body());
+        if (!$response->successful())
+            throw new MonnifyFailedRequestException(
+                $responseObject->responseMessage ?? "Path '{$responseObject->path}' {$responseObject->error}",
+                $responseObject->responseCode ?? $responseObject->status
+            );
+
+        return $responseObject->responseBody;
+    }
+
+
+    /**
      * Allows you get virtual account details for a transaction using the transactionReference of an initialized transaction.
      * This is useful if you want to control the payment interface.
      * There are a lot of UX considerations to keep in mind if you choose to do this so we recommend you read this @link https://docs.teamapt.com/display/MON/Optimizing+Your+User+Experience.

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -60,4 +60,37 @@ class TransactionsTest extends TestCase
         $response = Monnify::Transactions()->getTransactionStatus('TRX-001');
         $this->assertEquals('PAID', $response->paymentStatus);
     }
+
+    public function test_get_transaction_status_by_reference()
+    {
+        Http::fake([
+            '*/api/v1/auth/login' => Http::response(json_encode([
+                'requestSuccessful' => true,
+                'responseMessage'   => 'success',
+                'responseCode'      => '0',
+                'responseBody'      => ['accessToken' => 'access_token', 'expiresIn' => 3600]
+            ]), 200),
+            '*/api/v2/merchant/transactions/query*' => Http::response(json_encode([
+                'requestSuccessful' => true,
+                'responseMessage'   => 'success',
+                'responseCode'      => '0',
+                'responseBody'      => [
+                    'transactionReference' => 'MNFY|67|20220725111957|000283',
+                    'paymentReference'     => '12-3---03--1kls0a--dkad',
+                    'amountPaid'           => '100.00',
+                    'totalPayable'         => '100.00',
+                    'settlementAmount'     => '90.00',
+                    'paidOn'               => '25/07/2022 11:20:20 AM',
+                    'paymentStatus'        => 'PAID',
+                    'paymentDescription'   => 'Trial transaction',
+                    'currency'             => 'NGN',
+                    'paymentMethod'        => 'CARD',
+                ]
+            ]), 200),
+        ]);
+
+        $response = Monnify::Transactions()->getTransactionStatusByReference(paymentReference: '12-3---03--1kls0a--dkad');
+        $this->assertEquals('PAID', $response->paymentStatus);
+        $this->assertEquals('MNFY|67|20220725111957|000283', $response->transactionReference);
+    }
 }


### PR DESCRIPTION
…hitting `GET /api/v2/merchant/transactions/query` with optional `transactionReference` or `paymentReference` query params. All 3 tests pass. Ready to commit.

src/Transactions.php — new getTransactionStatusByReference() method:
- Accepts ?string $transactionReference and/or ?string $paymentReference (at least one required)   - Throws \InvalidArgumentException if both are null (caller error, not API error)                       - Builds query string with only the provided params via array_filter + http_build_query                 - GET /api/v2/merchant/transactions/query?{params} with OAuth2 auth                                    - Returns $responseObject->responseBody on success                                                      tests/Feature/TransactionsTest.php — new test_get_transaction_status_by_reference():         - Fakes the auth login + query endpoint (wildcard * handles the query string)                           - Uses named argument paymentReference: syntax to illustrate the flexible call pattern                - Asserts both paymentStatus and transactionReference from the response

The Monnify API exposes a "Get Transaction Status By Reference" endpoint (GET /api/v2/merchant/transactions/query) that accepts either a Monnify transactionReference or a merchant paymentReference as a query parameter. The existing getTransactionStatus() method looks up by Monnify's own reference as a path parameter (/api/v2/transactions/{ref}/). This new method targets a different endpoint and accepts merchant-side or Monnify-side references as query parameters — a distinct, missing capability.